### PR TITLE
feat: Allow user to see multiple pitches

### DIFF
--- a/src/components/BaseButton.stories.js
+++ b/src/components/BaseButton.stories.js
@@ -10,8 +10,20 @@ const Template = (args) => ({
   setup() {
     return { args }
   },
-  template: `<BaseButton>What a nice button!</BaseButton>`,
+  template: `
+    <BaseButton v-bind="args">
+      <span v-if="!args.isLoading">What a nice button!</span>
+      <span v-else>Nice loading text...</span>
+    </BaseButton>
+  `,
 })
 
 export const Primary = Template.bind({})
-Primary.args = {}
+Primary.args = {
+  isLoading: false,
+}
+
+export const LoadingState = Template.bind({})
+LoadingState.args = {
+  isLoading: true,
+}

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -1,7 +1,22 @@
 <template>
   <button
-    class="p-2 text-white rounded-lg bg-primary-indigo hover:bg-cool-black"
+    class="p-2 text-white rounded-lg"
+    :disabled="isLoading"
+    :class="
+      isLoading
+        ? 'bg-indigo-300 hover:bg-indigo-300'
+        : 'bg-primary-indigo hover:bg-cool-black'
+    "
   >
     <slot />
   </button>
 </template>
+
+<script setup>
+defineProps({
+  isLoading: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/src/components/ResultCard.stories.js
+++ b/src/components/ResultCard.stories.js
@@ -1,0 +1,24 @@
+import ResultCard from './ResultCard.vue'
+
+export default {
+  title: 'Result card (single)',
+  component: ResultCard,
+}
+
+const Template = (args) => ({
+  components: { ResultCard },
+  setup() {
+    return { args }
+  },
+  template: `<ResultCard v-bind="args" />`,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  text: `
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis nisi reprehenderit rem dicta totam ad temporibus recusandae quod. Dignissimos nesciunt quaerat aspernatur velit necessitatibus nam voluptatibus perferendis esse veritatis dicta.
+  Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis nisi reprehenderit rem dicta totam ad temporibus recusandae quod. Dignissimos nesciunt quaerat aspernatur velit necessitatibus nam voluptatibus perferendis esse veritatis dicta.
+  `,
+  time: '9:48:13 AM',
+  order: 123,
+}

--- a/src/components/ResultCard.vue
+++ b/src/components/ResultCard.vue
@@ -1,0 +1,35 @@
+<template>
+  <component
+    :is="tag"
+    class="flex flex-col-reverse border-4 border-neutral-200 rounded-2xl"
+  >
+    <h3
+      class="flex justify-end px-6 py-4 font-bold sm:justify-between bg-neutral-200"
+    >
+      <span class="hidden sm:inline-block"> Generated at {{ time }} </span>
+      <span>Job Description #{{ order }}</span>
+    </h3>
+    <p class="px-6 pt-4 pb-6">{{ text }}</p>
+  </component>
+</template>
+
+<script setup>
+defineProps({
+  tag: {
+    type: String,
+    default: 'li',
+  },
+  time: {
+    type: String,
+    required: true,
+  },
+  order: {
+    type: [String, Number],
+    required: true,
+  },
+  text: {
+    type: String,
+    required: true,
+  },
+})
+</script>

--- a/src/components/ResultCardLoading.stories.js
+++ b/src/components/ResultCardLoading.stories.js
@@ -1,0 +1,17 @@
+import ResultCardLoading from './ResultCardLoading.vue'
+
+export default {
+  title: 'Result card loading skeleton',
+  component: ResultCardLoading,
+}
+
+const Template = (args) => ({
+  components: { ResultCardLoading },
+  setup() {
+    return { args }
+  },
+  template: `<ResultCardLoading v-bind="args" />`,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {}

--- a/src/components/ResultCardLoading.vue
+++ b/src/components/ResultCardLoading.vue
@@ -1,0 +1,45 @@
+<template>
+  <div
+    role="alert"
+    aria-live="assertive"
+    class="flex flex-col-reverse w-full border-4 border-indigo-100 animate-pulse motion-safe:animate-none rounded-2xl"
+  >
+    <div class="flex justify-between px-6 py-4 font-bold bg-indigo-100">
+      <div class="hidden h-2 bg-indigo-200 rounded-lg w-52 sm:inline-block" />
+      <div class="h-2 bg-indigo-200 rounded-lg w-38 sm:w-1/5" />
+    </div>
+    <div class="block px-6 pt-4 pb-6">
+      <p class="mb-4 text-center text-indigo-400">
+        Generating a pop-out pitch!
+      </p>
+      <div class="grid grid-cols-3 grid-rows-2 gap-4">
+        <div class="h-2 col-span-2 row-span-1 bg-indigo-200 rounded"></div>
+        <div class="h-2 col-span-1 row-span-1 bg-indigo-200 rounded"></div>
+        <div class="h-2 col-span-1 row-span-2 bg-indigo-200 rounded"></div>
+        <div class="h-2 col-span-2 row-span-2 bg-indigo-200 rounded"></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.loader {
+  width: 100%;
+  height: 200px;
+  background: linear-gradient(0.25turn, transparent, #fff, transparent),
+    linear-gradient(#ddd, #ddd),
+    radial-gradient(38px circle at 19px 19px, #ddd 50%, transparent 51%),
+    linear-gradient(#ddd, #ddd);
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-size: 100% 200px, 100%x 130px, 100px 100px, 225px 30px;
+  background-position: 0% 0, 0 0, 15px 140px, 65px 145px;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  to {
+    background-position: 100% 0, 0 0, 15px 140px, 65px 145px;
+  }
+}
+</style>


### PR DESCRIPTION
## Card
[Jiara card 48](https://deborahod.atlassian.net/jira/software/projects/TTS/boards/2?selectedIssue=TTS-48)

## What this PR does...

- Allows user to see the pitches as they generate more
- Creates a mock card to show while the content is loading
- Tells the user the order of the job description they've just generated and at what time

## How to test...

1. Navigate to the preview URL.
2. Click generate to generate a new pitch.
- Expect to see a light, pulsing mock card.
3. Wait for content to load.
- Expect to see a new pitch, with the time generated and the order ("Job Description # 1," etc.)
4. Click generate again (optionally, you can fill in the inputs again).
- Expect to see a new pitch appear at the top of the list, with the correct order ("Job Description # 2") and the time generated.

## I learned...

I learned a bit about generating dates and times (resource: [MDN entry on date prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date))